### PR TITLE
Fix code scanning alert no. 13: Resource exhaustion

### DIFF
--- a/libs/scully/src/lib/utils/serverstuff/dataServer.ts
+++ b/libs/scully/src/lib/utils/serverstuff/dataServer.ts
@@ -62,6 +62,9 @@ export async function startDataServer(ssl: boolean) {
       if (isNaN(delay)) {
         delay = 1000;
       }
+      if (delay > 1000) {
+        delay = 1000;
+      }
       setTimeout(() => res.json({ delay, status: 'OK' }), delay);
     });
     dataServer.get('/*', (req, res) => {


### PR DESCRIPTION
Fixes [https://github.com/akadev1/symmetrical-octo-barnacle/security/code-scanning/13](https://github.com/akadev1/symmetrical-octo-barnacle/security/code-scanning/13)

To fix the problem, we need to impose an upper limit on the `delay` value to prevent excessively long delays that could lead to resource exhaustion. We will add a check to ensure that the `delay` value does not exceed a reasonable maximum (e.g., 1000 milliseconds). If the `delay` exceeds this limit, we will set it to the maximum allowed value.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
