### PR TITLE
Fix code scanning alert no. 6: Disabling certificate validation

### DIFF
--- a/libs/plugins/scully-plugin-local-cache/src/lib/http.ts
+++ b/libs/plugins/scully-plugin-local-cache/src/lib/http.ts
@@ -25,7 +25,6 @@ export function httpJson<T>(
   // You can ignore the warning (TLS) or run scully with --no-warning
   // ****************************************************************************************`);
   //   }
-  process.env['NODE_TLS_REJECT_UNAUTHORIZED'] = '0';
   const request = isSSL ? httpsRequest : httpRequest;
   return new Promise((resolve, reject) => {
     const { pathname, hostname, port, protocol, search, hash } = new URL(url);


### PR DESCRIPTION
Fixes [https://github.com/akadev1/symmetrical-octo-barnacle/security/code-scanning/6](https://github.com/akadev1/symmetrical-octo-barnacle/security/code-scanning/6)

To fix the problem, we should ensure that certificate validation is not disabled. Instead of setting `process.env['NODE_TLS_REJECT_UNAUTHORIZED']` to '0', we should remove or conditionally set this environment variable based on the environment (development vs. production). This ensures that in production environments, certificate validation remains enabled.

- Remove the line that sets `process.env['NODE_TLS_REJECT_UNAUTHORIZED']` to '0'.
- Optionally, add a conditional check to set this environment variable only in non-production environments.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
