### PR TITLE
Fix code scanning alert no. 11: Bad HTML filtering regexp

### DIFF
--- a/package.json
+++ b/package.json
@@ -119,7 +119,8 @@
     "selfsigned": "^2.0.0",
     "semver": "^7.3.5",
     "ws": "^8.5.0",
-    "zone.js": "0.11.4"
+    "zone.js": "0.11.4",
+    "sanitize-html": "^2.13.1"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "12.2.6",

--- a/tests/jest/src/test-config.helper.ts
+++ b/tests/jest/src/test-config.helper.ts
@@ -1,6 +1,7 @@
 import { TestBed } from '@angular/core/testing';
 import { readFileSync, existsSync } from 'fs';
 import { join } from 'path';
+import sanitizeHtml from 'sanitize-html';
 
 const SCULLY_STATE_START = `/** ___SCULLY_STATE_START___ */`;
 const SCULLY_STATE_END = `/** ___SCULLY_STATE_END___ */`;
@@ -25,28 +26,14 @@ export const configureTests = (configure: ConfigureFn, compilerOptions: Compiler
 };
 
 export const replaceIndexNG = (index: string) => {
-  let previous;
-  do {
-    previous = index;
-    index = index
-      /** take out meta tag */
-      .replace(/ content=[\"\']Scully(.*)[\"\']/g, '')
-      /** take out scully version from body tag */
-      .replace(/scully-version=[\"\'](.*)[\"\']/gi, '')
-      /** take out ngContent and ngHost attributes */
-      .replace(/\_ng(content|host)([\-A-Za-z0-9]*)/g, '')
-      /** take out ng-version attribute */
-      .replace(/ng\-version\=\".{5,30}\"/g, '')
-      /** take out all script tags... DEBATABLE!!! */
-      .replace(/<script[\d\D]*?>[\d\D]*?<\/script>/gi, '')
-      /** take out all styles (they differ between renderers) */
-      .replace(/<style(?:.*)<\/style>/gis, '')
-      /** take out ng-transition styles */
-      // .replace(/<style.?ng-transition(?:.*)<\/style>/gis, '')
-      /** take out sourcemaps */
-      .replace(/\/\*# sourceMappingURL.*\*\//g, '');
-  } while (index !== previous);
-  return index;
+  const cleanIndex = sanitizeHtml(index, {
+    allowedTags: sanitizeHtml.defaults.allowedTags.filter(tag => tag !== 'script' && tag !== 'style'),
+    allowedAttributes: {
+      '*': ['!ng-*', '!scully-version', '!ng-version']
+    },
+    allowedSchemes: sanitizeHtml.defaults.allowedSchemes.concat(['data'])
+  });
+  return cleanIndex;
 };
 
 export const extractTransferState = (index: string) => {


### PR DESCRIPTION
Fixes [https://github.com/akadev1/symmetrical-octo-barnacle/security/code-scanning/11](https://github.com/akadev1/symmetrical-octo-barnacle/security/code-scanning/11)

To fix the problem, we should replace the custom regular expression with a well-tested HTML sanitization library. One such library is `sanitize-html`, which provides robust and configurable HTML sanitization.

1. Install the `sanitize-html` library.
2. Replace the custom regex-based sanitization with `sanitize-html` to remove script tags and other unwanted elements.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
