### PR TITLE
Fix code scanning alert no. 12: Resource exhaustion

### DIFF
--- a/libs/scully/src/lib/utils/serverstuff/dataServer.ts
+++ b/libs/scully/src/lib/utils/serverstuff/dataServer.ts
@@ -19,7 +19,10 @@ export async function startDataServer(ssl: boolean) {
       const { delay }: { delay: string } = req.query;
       if (delay) {
         /** get the number to pause 0 and invalid numbers will be 100 instead */
-        const pause = parseInt(delay, 10) || 100;
+        let pause = parseInt(delay, 10) || 100;
+        if (pause > 1000) {
+          pause = 1000;
+        }
         return setTimeout(next, pause);
       }
       next();


### PR DESCRIPTION
Fixes [https://github.com/akadev1/symmetrical-octo-barnacle/security/code-scanning/12](https://github.com/akadev1/symmetrical-octo-barnacle/security/code-scanning/12)

To fix the problem, we need to enforce an upper limit on the `pause` value derived from the `delay` parameter. This will prevent excessively large timeouts that could lead to resource exhaustion. We will add a check to ensure that if the `pause` value exceeds a certain threshold (e.g., 1000 milliseconds), it will be capped at that threshold.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
