### PR TITLE
Fix code scanning alert no. 8: Incomplete string escaping or encoding

### DIFF
--- a/libs/plugins/scully-plugin-flash-prevention/src/lib/flash-prevention.plugin.ts
+++ b/libs/plugins/scully-plugin-flash-prevention/src/lib/flash-prevention.plugin.ts
@@ -125,7 +125,7 @@ function pushItemsToArray(src, dest) {
 
 function fetchCleanedOpenTag(str: string, arr: string[]): string {
   return str
-    .replace('>', ' >')
+    .replace(/>/g, ' >')
     .split(' ')
     .reduce((acc, attr) => {
       // Does the html attr exist in the blacklisted attrs


### PR DESCRIPTION
Fixes [https://github.com/akadev1/symmetrical-octo-barnacle/security/code-scanning/8](https://github.com/akadev1/symmetrical-octo-barnacle/security/code-scanning/8)

To fix the problem, we need to ensure that all occurrences of the '>' character in the string are replaced. This can be achieved by using a regular expression with the global flag (`g`). This change will ensure that every '>' character in the string is replaced, not just the first one.

- Modify the `replace` method on line 127 to use a regular expression with the global flag.
- No additional imports or dependencies are required for this change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
